### PR TITLE
fix: trigger rebuildHandlers on new RegistryService.AddDescriptors

### DIFF
--- a/private/server/server.go
+++ b/private/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 
@@ -81,6 +82,10 @@ func (s *server) Reset() error {
 	return s.rebuildHandlers()
 }
 
+func (s *server) RegisterFile(fd protoreflect.FileDescriptor) error {
+	return s.AddFile(fd)
+}
+
 func (s *server) AddFile(fd protoreflect.FileDescriptor) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -95,6 +100,7 @@ func (s *server) AddFileFromPath(path string) error {
 }
 
 func (s *server) rebuildHandlers() error {
+	slog.Debug("Rebuilding handlers")
 	serviceNames := []string{}
 	vgservices := []*vanguard.Service{}
 	var validate protovalidate.Validator


### PR DESCRIPTION
Fixes https://github.com/sudorandom/fauxrpc/issues/25

The `RegisterFile` function on server now calls rebuildHandlers(), which regenerate documentation, ensures server reflection is updated with the current list of services, etc.