### PR TITLE
fix: don't allow extra fields when parsing stubs yaml/json; add stuibs jsonschema

### DIFF
--- a/cmd/fauxrpc/cmd_run.go
+++ b/cmd/fauxrpc/cmd_run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -208,7 +209,9 @@ func addStubsFromFile(srv server.Server, stubsPath string) error {
 				}
 				contents = standardContents
 			}
-			if err := json.Unmarshal(contents, &stubFile); err != nil {
+			decoder := json.NewDecoder(bytes.NewReader(contents))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&stubFile); err != nil {
 				return fmt.Errorf("json.Unmarshal: %s: %w", path, err)
 			}
 		case ".yaml":
@@ -216,7 +219,9 @@ func addStubsFromFile(srv server.Server, stubsPath string) error {
 			if err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}
-			if err := yaml.Unmarshal(contents, &stubFile); err != nil {
+			decoder := yaml.NewDecoder(bytes.NewReader(contents))
+			decoder.KnownFields(true)
+			if err := decoder.Decode(&stubFile); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}
 		}

--- a/example/stubs.eliza/say.json
+++ b/example/stubs.eliza/say.json
@@ -1,0 +1,31 @@
+{
+  "stubs": [
+    {
+      "id": "say-hello-default",
+      "target": "connectrpc.eliza.v1.ElizaService/Say",
+      "cel_content": "{'sentence': req.sentence}"
+    },
+    {
+      "id": "say-with-quote",
+      "target": "connectrpc.eliza.v1.ElizaService/Say",
+      "cel_content": "{'sentence': fake_quote()}"
+    },
+    {
+      "id": "say-with-question",
+      "target": "connectrpc.eliza.v1.ElizaService/Say",
+      "cel_content": "{'sentence': fake_question()}"
+    },
+    {
+      "id": "say-with-notfound",
+      "target": "connectrpc.eliza.v1.ElizaService/Say",
+      "error_code": 5,
+      "error_message": "not found"
+    },
+    {
+      "id": "say-with-error",
+      "target": "connectrpc.eliza.v1.ElizaService/Say",
+      "error_code": 13,
+      "error_message": "internal server error"
+    }
+  ]
+}

--- a/example/stubs.eliza/say.yaml
+++ b/example/stubs.eliza/say.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 stubs:
   - id: say-hello-default
     target: connectrpc.eliza.v1.ElizaService/Say

--- a/example/stubs.petstore/AddPet.yaml
+++ b/example/stubs.petstore/AddPet.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: add-pet

--- a/example/stubs.petstore/DeletePet.yaml
+++ b/example/stubs.petstore/DeletePet.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: delete-pet-empty

--- a/example/stubs.petstore/FindPetsByStatus.yaml
+++ b/example/stubs.petstore/FindPetsByStatus.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: find-pets-by-status

--- a/example/stubs.petstore/FindPetsByTag.yaml
+++ b/example/stubs.petstore/FindPetsByTag.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: find-pets-by-tag

--- a/example/stubs.petstore/GetPetByID.yaml
+++ b/example/stubs.petstore/GetPetByID.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: get-pets-by-id-id-1

--- a/example/stubs.petstore/UpdatePet.yaml
+++ b/example/stubs.petstore/UpdatePet.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: update-pet

--- a/example/stubs.petstore/UpdatePetWithForm.yaml
+++ b/example/stubs.petstore/UpdatePetWithForm.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: update-pet-with-form

--- a/example/stubs.petstore/UploadFile.yaml
+++ b/example/stubs.petstore/UploadFile.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../stubs.schema.json
 ---
 stubs:
 - id: upload-file

--- a/stubs.schema.json
+++ b/stubs.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FauxRPC Stub Configuration",
+  "description": "Schema for FauxRPC stub configuration files, supporting both JSON and YAML formats.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stubs": {
+      "type": "array",
+      "description": "A list of stub definitions.",
+      "items": {
+        "$ref": "#/definitions/Stub"
+      }
+    }
+  },
+  "required": ["stubs"],
+  "definitions": {
+    "Stub": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defines a single FauxRPC stub.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the stub. If not provided, a random one will be generated."
+        },
+        "target": {
+          "type": "string",
+          "description": "The fully qualified name of the service method or message type this stub applies to (e.g., 'connectrpc.eliza.v1.ElizaService/Say' or 'google.protobuf.Any')."
+        },
+        "active_if": {
+          "type": "string",
+          "description": "A Common Expression Language (CEL) expression that must evaluate to true for this stub to be active. The request message is available as 'req'."
+        },
+        "priority": {
+          "type": "integer",
+          "description": "An integer representing the priority of the stub. Higher values indicate higher priority. Stubs with higher priority are evaluated first."
+        },
+        "content": {
+          "type": "object",
+          "description": "A JSON string representing the response message. This will be unmarshaled into the appropriate protobuf message type."
+        },
+        "cel_content": {
+          "type": "string",
+          "description": "A Common Expression Language (CEL) expression that evaluates to the response message. The request message is available as 'req', and faker functions are available (e.g., 'fake_name()')."
+        },
+        "error_code": {
+          "type": "integer",
+          "description": "The gRPC status code (e.g., 0 for OK, 5 for NOT_FOUND, 13 for INTERNAL)."
+        },
+        "error_message": {
+          "type": "string",
+          "description": "A human-readable error message."
+        }
+      },
+      "required": ["target"],
+      "errorMessage": "A stub must define exactly one of 'cel_content', 'json', 'proto', or 'error'."
+    }
+  }
+}


### PR DESCRIPTION
Resolves #33.

This PR configures the JSON and YAML parsers to not accept unknown fields. This will make it less likely for mistakes to go un-noticed.

Also, this adds a jsonschema for the stubs file format. It's `stubs.schema.json` at the root.