### PR TITLE
fix: handle conversion from go type to proto type for integer/float scalars

### DIFF
--- a/protocel/cel.go
+++ b/protocel/cel.go
@@ -8,13 +8,14 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
 	"github.com/sudorandom/fauxrpc"
 	"github.com/sudorandom/fauxrpc/celfakeit"
 	stubsv1 "github.com/sudorandom/fauxrpc/private/gen/stubs/v1"
 	"github.com/sudorandom/fauxrpc/private/registry"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 type CELMessage interface {
@@ -233,6 +234,64 @@ func (p *protocel) celToValue(fd protoreflect.FieldDescriptor, val any) (protore
 					return protoreflect.ValueOf(nil), fmt.Errorf("unknown enum value: '%s'", t)
 				}
 				return protoreflect.ValueOfEnum(v.Number()), nil
+			}
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+			switch t := val.(type) {
+			case int64:
+				return protoreflect.ValueOfInt32(int32(t)), nil
+			case uint64:
+				return protoreflect.ValueOfInt32(int32(t)), nil
+			case int32:
+				return protoreflect.ValueOfInt32(t), nil
+			}
+		case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+			switch t := val.(type) {
+			case int64:
+				return protoreflect.ValueOfUint32(uint32(t)), nil
+			case uint64:
+				return protoreflect.ValueOfUint32(uint32(t)), nil
+			case uint32:
+				return protoreflect.ValueOfUint32(t), nil
+			}
+		case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+			switch t := val.(type) {
+			case int64:
+				return protoreflect.ValueOfInt64(t), nil
+			case uint64:
+				return protoreflect.ValueOfInt64(int64(t)), nil
+			case int32:
+				return protoreflect.ValueOfInt64(int64(t)), nil
+			}
+		case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+			switch t := val.(type) {
+			case int64:
+				return protoreflect.ValueOfUint64(uint64(t)), nil
+			case uint64:
+				return protoreflect.ValueOfUint64(t), nil
+			case uint32:
+				return protoreflect.ValueOfUint64(uint64(t)), nil
+			}
+		case protoreflect.FloatKind:
+			switch t := val.(type) {
+			case float64:
+				return protoreflect.ValueOfFloat32(float32(t)), nil
+			case float32:
+				return protoreflect.ValueOfFloat32(t), nil
+			case int64:
+				return protoreflect.ValueOfFloat32(float32(t)), nil
+			case uint64:
+				return protoreflect.ValueOfFloat32(float32(t)), nil
+			}
+		case protoreflect.DoubleKind:
+			switch t := val.(type) {
+			case float64:
+				return protoreflect.ValueOfFloat64(t), nil
+			case float32:
+				return protoreflect.ValueOfFloat64(float64(t)), nil
+			case int64:
+				return protoreflect.ValueOfFloat64(float64(t)), nil
+			case uint64:
+				return protoreflect.ValueOfFloat64(float64(t)), nil
 			}
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/sudorandom/fauxrpc/issues/41

Handles the conversion from the Go type to the Proto type. This follows the guide from: https://protobuf.dev/programming-guides/proto3/