### PR TITLE
⚡ Fix unsafe map iteration in ForEachService

### DIFF
--- a/private/registry/registry.go
+++ b/private/registry/registry.go
@@ -108,9 +108,8 @@ func (r *serviceRegistry) ServiceCount() int {
 
 func (r *serviceRegistry) ForEachService(cb func(protoreflect.ServiceDescriptor) bool) {
 	r.lock.RLock()
-	services := r.services
-	r.lock.RUnlock()
-	for _, service := range services {
+	defer r.lock.RUnlock()
+	for _, service := range r.services {
 		if !cb(service) {
 			break
 		}

--- a/private/registry/registry_bench_test.go
+++ b/private/registry/registry_bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkForEachService_InsideRLock(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.lock.RLock()
-		for _, _ = range r.services {
+		for range r.services {
 			if !true {
 				break
 			}
@@ -74,7 +74,7 @@ func BenchmarkForEachService_Slice(b *testing.B) {
 			services = append(services, s)
 		}
 		r.lock.RUnlock()
-		for _, _ = range services {
+		for range services {
 			if !true {
 				break
 			}

--- a/private/registry/registry_bench_test.go
+++ b/private/registry/registry_bench_test.go
@@ -1,0 +1,83 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// A dummy service descriptor
+type dummyServiceDescriptor struct {
+    protoreflect.ServiceDescriptor
+    name protoreflect.FullName
+}
+
+func (d dummyServiceDescriptor) FullName() protoreflect.FullName {
+    return d.name
+}
+
+func BenchmarkForEachService_Current(b *testing.B) {
+	r, err := NewServiceRegistry()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		r.addService(dummyServiceDescriptor{name: protoreflect.FullName(fmt.Sprintf("service_%d", i))})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.ForEachService(func(sd protoreflect.ServiceDescriptor) bool {
+			return true
+		})
+	}
+}
+
+func BenchmarkForEachService_InsideRLock(b *testing.B) {
+	r, err := NewServiceRegistry()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		r.addService(dummyServiceDescriptor{name: protoreflect.FullName(fmt.Sprintf("service_%d", i))})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.lock.RLock()
+		for _, _ = range r.services {
+			if !true {
+				break
+			}
+		}
+		r.lock.RUnlock()
+	}
+}
+
+func BenchmarkForEachService_Slice(b *testing.B) {
+	r, err := NewServiceRegistry()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		r.addService(dummyServiceDescriptor{name: protoreflect.FullName(fmt.Sprintf("service_%d", i))})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.lock.RLock()
+		services := make([]protoreflect.ServiceDescriptor, 0, len(r.services))
+		for _, s := range r.services {
+			services = append(services, s)
+		}
+		r.lock.RUnlock()
+		for _, _ = range services {
+			if !true {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
💡 **What:** Modified `ForEachService` in `private/registry/registry.go` to hold `RLock()` throughout the map iteration instead of copying the map reference and iterating unlocked.

🎯 **Why:** Iterating over a Go map concurrently with additions (e.g. from `addService`) without a lock causes runtime panics. Assigning the map under the lock (`services := r.services`) only copied the reference, meaning the unlocked iteration was still iterating the original map data. Holding the RLock() during iteration resolves the safety issue without allocations.

📊 **Measured Improvement:** No performance degradation and 0 extra memory allocations were added. Creating a slice alternative would have added ~16KB per call in large registries, but by deferring `RUnlock()`, performance remained identical to the baseline (both map iterations) while achieving thread-safety. Included benchmarks in `private/registry/registry_bench_test.go` to verify these numbers.

---
*PR created automatically by Jules for task [4973022860422588748](https://jules.google.com/task/4973022860422588748) started by @sudorandom*