### PR TITLE
feat: add support deflate encoding

### DIFF
--- a/private/grpc/encoding.go
+++ b/private/grpc/encoding.go
@@ -3,18 +3,48 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sync"
+	"strings"
 )
 
-var gzipReaderPool = sync.Pool{
-	New: func() any { return new(gzip.Reader) },
+type compressionCodec interface {
+	NewReader(io.Reader) (io.ReadCloser, error)
+	NewWriter(io.Writer) (io.WriteCloser, error)
 }
 
-var gzipWriterPool = sync.Pool{
-	New: func() any { return gzip.NewWriter(io.Discard) },
+type compressionCodecFuncs struct {
+	newReader func(io.Reader) (io.ReadCloser, error)
+	newWriter func(io.Writer) (io.WriteCloser, error)
+}
+
+func (c compressionCodecFuncs) NewReader(r io.Reader) (io.ReadCloser, error) {
+	return c.newReader(r)
+}
+
+func (c compressionCodecFuncs) NewWriter(w io.Writer) (io.WriteCloser, error) {
+	return c.newWriter(w)
+}
+
+var compressionCodecs = map[string]compressionCodec{
+	"gzip": compressionCodecFuncs{
+		newReader: func(r io.Reader) (io.ReadCloser, error) {
+			return gzip.NewReader(r)
+		},
+		newWriter: func(w io.Writer) (io.WriteCloser, error) {
+			return gzip.NewWriter(w), nil
+		},
+	},
+	"deflate": compressionCodecFuncs{
+		newReader: func(r io.Reader) (io.ReadCloser, error) {
+			return zlib.NewReader(r)
+		},
+		newWriter: func(w io.Writer) (io.WriteCloser, error) {
+			return zlib.NewWriter(w), nil
+		},
+	},
 }
 
 // WriteGRPCMessage writes an uncompressed gRPC length-prefixed message.
@@ -33,18 +63,21 @@ func WriteGRPCMessage(w io.Writer, msg []byte) error {
 // WriteGRPCMessageGzip writes a gzip-compressed gRPC length-prefixed message.
 // The compression flag byte is set to 1.
 func WriteGRPCMessageGzip(w io.Writer, msg []byte) error {
+	return WriteGRPCMessageCompressed(w, msg, "gzip")
+}
+
+// WriteGRPCMessageCompressed writes a compressed gRPC length-prefixed message.
+// The compression flag byte is set to 1.
+func WriteGRPCMessageCompressed(w io.Writer, msg []byte, encoding string) error {
+	codec, ok := lookupCompressionCodec(encoding)
+	if !ok {
+		return fmt.Errorf("grpc: unsupported compression encoding %q", encoding)
+	}
+
 	var buf bytes.Buffer
-	gz := gzipWriterPool.Get().(*gzip.Writer)
-	gz.Reset(&buf)
-	if _, err := gz.Write(msg); err != nil {
-		gzipWriterPool.Put(gz)
-		return fmt.Errorf("grpc: gzip write: %w", err)
+	if err := writeCompressedPayload(&buf, msg, codec); err != nil {
+		return fmt.Errorf("grpc: %s write: %w", encoding, err)
 	}
-	if err := gz.Close(); err != nil {
-		gzipWriterPool.Put(gz)
-		return fmt.Errorf("grpc: gzip close: %w", err)
-	}
-	gzipWriterPool.Put(gz)
 
 	compressed := buf.Bytes()
 	var prefix [5]byte
@@ -59,10 +92,35 @@ func WriteGRPCMessageGzip(w io.Writer, msg []byte) error {
 	return nil
 }
 
+func lookupCompressionCodec(encoding string) (compressionCodec, bool) {
+	codec, ok := compressionCodecs[strings.ToLower(strings.TrimSpace(encoding))]
+	return codec, ok
+}
+
+func writeCompressedPayload(w io.Writer, msg []byte, codec compressionCodec) error {
+	cw, err := codec.NewWriter(w)
+	if err != nil {
+		return err
+	}
+	if _, err := cw.Write(msg); err != nil {
+		_ = cw.Close()
+		return err
+	}
+	return cw.Close()
+}
+
 // ReadGRPCMessage reads a gRPC length-prefixed message from body into msg.
 // If the compression flag is set to 1 (gzip), the payload is decompressed
 // transparently before being written into msg.
 func ReadGRPCMessage(body io.Reader, msg []byte) (int, error) {
+	return ReadGRPCMessageWithEncoding(body, msg, "gzip")
+}
+
+// ReadGRPCMessageWithEncoding reads a gRPC length-prefixed message from body
+// into msg. If the compression flag is set to 1, the payload is decompressed
+// using encoding. The gRPC "deflate" encoding is the zlib structure from RFC
+// 1950 carrying the deflate algorithm from RFC 1951, never raw deflate data.
+func ReadGRPCMessageWithEncoding(body io.Reader, msg []byte, encoding string) (int, error) {
 	prefixes := [5]byte{}
 	if _, err := io.ReadFull(body, prefixes[:]); err != nil {
 		if err == io.EOF {
@@ -86,20 +144,28 @@ func ReadGRPCMessage(body io.Reader, msg []byte) (int, error) {
 		return n, nil
 	}
 
-	// Decompress gzip-encoded payload.
-	gr := gzipReaderPool.Get().(*gzip.Reader)
-	if resetErr := gr.Reset(bytes.NewReader(msg[:n])); resetErr != nil {
-		gzipReaderPool.Put(gr)
-		return 0, fmt.Errorf("failed to init gzip reader: %w", resetErr)
+	if strings.TrimSpace(encoding) == "" || strings.EqualFold(strings.TrimSpace(encoding), "identity") {
+		return 0, fmt.Errorf("compressed message missing grpc-encoding")
 	}
-	decompressed, readErr := io.ReadAll(gr)
-	closeErr := gr.Close()
-	gzipReaderPool.Put(gr)
+	codec, ok := lookupCompressionCodec(encoding)
+	if !ok {
+		return 0, fmt.Errorf("unsupported grpc-encoding %q", encoding)
+	}
+	return readCompressedPayload(msg, n, codec)
+}
+
+func readCompressedPayload(msg []byte, n int, codec compressionCodec) (int, error) {
+	cr, err := codec.NewReader(bytes.NewReader(msg[:n]))
+	if err != nil {
+		return 0, fmt.Errorf("failed to init compression reader: %w", err)
+	}
+	decompressed, readErr := io.ReadAll(cr)
+	closeErr := cr.Close()
 	if readErr != nil {
 		return 0, fmt.Errorf("failed to decompress message: %w", readErr)
 	}
 	if closeErr != nil {
-		return 0, fmt.Errorf("failed to close gzip reader: %w", closeErr)
+		return 0, fmt.Errorf("failed to close compression reader: %w", closeErr)
 	}
 	copy(msg, decompressed)
 	return len(decompressed), nil

--- a/private/grpc/encoding_test.go
+++ b/private/grpc/encoding_test.go
@@ -2,7 +2,9 @@ package grpc
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/binary"
 	"io"
 	"testing"
@@ -35,6 +37,36 @@ func makeGzipFrame(payload []byte) []byte {
 	return frame
 }
 
+// makeDeflateFrame builds a raw gRPC length-prefixed frame with flag=1 (zlib-wrapped deflate).
+func makeDeflateFrame(payload []byte) []byte {
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	_, _ = zw.Write(payload)
+	_ = zw.Close()
+	compressed := buf.Bytes()
+
+	frame := make([]byte, 5+len(compressed))
+	frame[0] = 1
+	binary.BigEndian.PutUint32(frame[1:], uint32(len(compressed)))
+	copy(frame[5:], compressed)
+	return frame
+}
+
+// makeRawDeflateFrame builds a compressed gRPC frame with raw RFC 1951 bytes.
+func makeRawDeflateFrame(payload []byte) []byte {
+	var buf bytes.Buffer
+	fw, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+	_, _ = fw.Write(payload)
+	_ = fw.Close()
+	compressed := buf.Bytes()
+
+	frame := make([]byte, 5+len(compressed))
+	frame[0] = 1
+	binary.BigEndian.PutUint32(frame[1:], uint32(len(compressed)))
+	copy(frame[5:], compressed)
+	return frame
+}
+
 // --- ReadGRPCMessage ---
 
 func TestReadGRPCMessage_Uncompressed(t *testing.T) {
@@ -53,6 +85,16 @@ func TestReadGRPCMessage_Gzip(t *testing.T) {
 
 	buf := make([]byte, 4096)
 	n, err := ReadGRPCMessage(bytes.NewReader(frame), buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, buf[:n])
+}
+
+func TestReadGRPCMessageWithEncoding_DeflateUsesZlib(t *testing.T) {
+	payload := []byte("hello zlib-wrapped deflate world")
+	frame := makeDeflateFrame(payload)
+
+	buf := make([]byte, 4096)
+	n, err := ReadGRPCMessageWithEncoding(bytes.NewReader(frame), buf, "deflate")
 	require.NoError(t, err)
 	assert.Equal(t, payload, buf[:n])
 }
@@ -90,6 +132,15 @@ func TestReadGRPCMessage_MultipleFrames(t *testing.T) {
 	n2, err := ReadGRPCMessage(r, readBuf)
 	require.NoError(t, err)
 	assert.Equal(t, payload2, readBuf[:n2])
+}
+
+func TestReadGRPCMessageWithEncoding_DeflateRejectsRawDeflate(t *testing.T) {
+	payload := []byte("raw deflate is not grpc deflate")
+	frame := makeRawDeflateFrame(payload)
+
+	buf := make([]byte, 4096)
+	_, err := ReadGRPCMessageWithEncoding(bytes.NewReader(frame), buf, "deflate")
+	require.Error(t, err)
 }
 
 func TestReadGRPCMessage_InvalidGzip(t *testing.T) {
@@ -140,6 +191,25 @@ func TestWriteGRPCMessageGzip_SetsCompressedFlag(t *testing.T) {
 	assert.Equal(t, payload, decompressed)
 }
 
+func TestWriteGRPCMessageCompressed_DeflateUsesZlib(t *testing.T) {
+	payload := []byte("hello deflate")
+	var buf bytes.Buffer
+	require.NoError(t, WriteGRPCMessageCompressed(&buf, payload, "deflate"))
+
+	b := buf.Bytes()
+	require.GreaterOrEqual(t, len(b), 5)
+	assert.Equal(t, byte(1), b[0], "compression flag should be 1")
+
+	size := binary.BigEndian.Uint32(b[1:5])
+	compressed := b[5 : 5+size]
+	zr, err := zlib.NewReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	assert.Equal(t, payload, decompressed)
+}
+
 // --- Round-trip ---
 
 func TestRoundTrip_WriteGzip_ReadGzip(t *testing.T) {
@@ -150,6 +220,18 @@ func TestRoundTrip_WriteGzip_ReadGzip(t *testing.T) {
 
 	readBuf := make([]byte, 4096)
 	n, err := ReadGRPCMessage(&buf, readBuf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, readBuf[:n])
+}
+
+func TestRoundTrip_WriteDeflate_ReadDeflate(t *testing.T) {
+	payload := []byte("round-trip zlib-wrapped deflate payload")
+	var buf bytes.Buffer
+
+	require.NoError(t, WriteGRPCMessageCompressed(&buf, payload, "deflate"))
+
+	readBuf := make([]byte, 4096)
+	n, err := ReadGRPCMessageWithEncoding(&buf, readBuf, "deflate")
 	require.NoError(t, err)
 	assert.Equal(t, payload, readBuf[:n])
 }

--- a/private/server/encoding.go
+++ b/private/server/encoding.go
@@ -5,29 +5,48 @@ import (
 	"strings"
 )
 
-// clientAcceptsGzip reports whether the client has indicated it can decode
-// gzip-compressed response frames. Per the gRPC spec:
+// responseCompressionEncoding returns the compression encoding the server
+// should use for response frames, or "" for identity. Per the gRPC spec:
 //
 //   - grpc-accept-encoding lists the compression algorithms the client can
-//     decode in responses (comma-separated, case-insensitive). If it includes
-//     "gzip" we should compress responses.
+//     decode in responses (comma-separated, case-insensitive). Prefer gzip,
+//     then deflate.
 //
-//   - If grpc-accept-encoding is absent but the client sent a gzip-encoded
-//     request (grpc-encoding: gzip), it implicitly accepts gzip responses too,
+//   - If grpc-accept-encoding is absent but the client sent a compressed
+//     request, it implicitly accepts responses using the same encoding,
 //     so we mirror the encoding.
 //
 // Reference: https://grpc.github.io/grpc/core/md_doc_compression.html
-func clientAcceptsGzip(r *http.Request) bool {
+func responseCompressionEncoding(r *http.Request) string {
 	if accept := r.Header.Get("grpc-accept-encoding"); accept != "" {
 		// grpc-accept-encoding is the authoritative list of what the client can
-		// decode. Only use the grpc-encoding fallback when it is absent entirely.
+		// decode. Only use the grpc-encoding fallback when it is absent.
+		var acceptsDeflate bool
 		for enc := range strings.SplitSeq(accept, ",") {
-			if strings.EqualFold(strings.TrimSpace(enc), "gzip") {
-				return true
+			switch strings.ToLower(strings.TrimSpace(enc)) {
+			case "gzip":
+				return "gzip"
+			case "deflate":
+				acceptsDeflate = true
 			}
 		}
-		return false
+		if acceptsDeflate {
+			return "deflate"
+		}
+		return ""
 	}
-	// Fallback: if the client sent a gzip request it must be able to decode gzip.
-	return strings.EqualFold(strings.TrimSpace(r.Header.Get("grpc-encoding")), "gzip")
+	switch strings.ToLower(strings.TrimSpace(r.Header.Get("grpc-encoding"))) {
+	case "gzip":
+		return "gzip"
+	case "deflate":
+		return "deflate"
+	default:
+		return ""
+	}
+}
+
+// clientAcceptsGzip reports whether the client has indicated it can decode
+// gzip-compressed response frames.
+func clientAcceptsGzip(r *http.Request) bool {
+	return responseCompressionEncoding(r) == "gzip"
 }

--- a/private/server/encoding_test.go
+++ b/private/server/encoding_test.go
@@ -20,10 +20,10 @@ import (
 
 func TestClientAcceptsGzip(t *testing.T) {
 	cases := []struct {
-		name            string
-		grpcEncoding    string
-		grpcAcceptEnc   string
-		expectAccepted  bool
+		name           string
+		grpcEncoding   string
+		grpcAcceptEnc  string
+		expectAccepted bool
 	}{
 		{
 			name:           "no headers — no gzip",
@@ -40,23 +40,23 @@ func TestClientAcceptsGzip(t *testing.T) {
 			expectAccepted: false,
 		},
 		{
-			name:          "grpc-accept-encoding: gzip only",
-			grpcAcceptEnc: "gzip",
+			name:           "grpc-accept-encoding: gzip only",
+			grpcAcceptEnc:  "gzip",
 			expectAccepted: true,
 		},
 		{
-			name:          "grpc-accept-encoding: identity,gzip",
-			grpcAcceptEnc: "identity,gzip",
+			name:           "grpc-accept-encoding: identity,gzip",
+			grpcAcceptEnc:  "identity,gzip",
 			expectAccepted: true,
 		},
 		{
-			name:          "grpc-accept-encoding: gzip,deflate",
-			grpcAcceptEnc: "gzip,deflate",
+			name:           "grpc-accept-encoding: gzip,deflate",
+			grpcAcceptEnc:  "gzip,deflate",
 			expectAccepted: true,
 		},
 		{
-			name:          "grpc-accept-encoding: identity only",
-			grpcAcceptEnc: "identity",
+			name:           "grpc-accept-encoding: identity only",
+			grpcAcceptEnc:  "identity",
 			expectAccepted: false,
 		},
 		{
@@ -68,18 +68,18 @@ func TestClientAcceptsGzip(t *testing.T) {
 			expectAccepted: false,
 		},
 		{
-			name:          "grpc-accept-encoding with whitespace around gzip",
-			grpcAcceptEnc: "identity, gzip , deflate",
+			name:           "grpc-accept-encoding with whitespace around gzip",
+			grpcAcceptEnc:  "identity, gzip , deflate",
 			expectAccepted: true,
 		},
 		{
-			name:          "grpc-accept-encoding: GZIP (case-insensitive)",
-			grpcAcceptEnc: "GZIP",
+			name:           "grpc-accept-encoding: GZIP (case-insensitive)",
+			grpcAcceptEnc:  "GZIP",
 			expectAccepted: true,
 		},
 		{
-			name:          "grpc-accept-encoding: Gzip (mixed case)",
-			grpcAcceptEnc: "Gzip",
+			name:           "grpc-accept-encoding: Gzip (mixed case)",
+			grpcAcceptEnc:  "Gzip",
 			expectAccepted: true,
 		},
 	}
@@ -95,6 +95,64 @@ func TestClientAcceptsGzip(t *testing.T) {
 				req.Header.Set("grpc-accept-encoding", tc.grpcAcceptEnc)
 			}
 			assert.Equal(t, tc.expectAccepted, clientAcceptsGzip(req))
+		})
+	}
+}
+
+func TestResponseCompressionEncoding(t *testing.T) {
+	cases := []struct {
+		name           string
+		grpcEncoding   string
+		grpcAcceptEnc  string
+		expectEncoding string
+	}{
+		{
+			name: "no compression headers",
+		},
+		{
+			name:           "mirror gzip request when accept is absent",
+			grpcEncoding:   "gzip",
+			expectEncoding: "gzip",
+		},
+		{
+			name:           "mirror deflate request when accept is absent",
+			grpcEncoding:   "deflate",
+			expectEncoding: "deflate",
+		},
+		{
+			name:           "prefer gzip over deflate when both are accepted",
+			grpcAcceptEnc:  "deflate,gzip",
+			expectEncoding: "gzip",
+		},
+		{
+			name:           "use deflate when it is the only supported accepted encoding",
+			grpcAcceptEnc:  "identity, deflate",
+			expectEncoding: "deflate",
+		},
+		{
+			name:           "accept header overrides request encoding",
+			grpcEncoding:   "deflate",
+			grpcAcceptEnc:  "identity",
+			expectEncoding: "",
+		},
+		{
+			name:           "case-insensitive deflate",
+			grpcAcceptEnc:  "DEFLATE",
+			expectEncoding: "deflate",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/", nil)
+			require.NoError(t, err)
+			if tc.grpcEncoding != "" {
+				req.Header.Set("grpc-encoding", tc.grpcEncoding)
+			}
+			if tc.grpcAcceptEnc != "" {
+				req.Header.Set("grpc-accept-encoding", tc.grpcAcceptEnc)
+			}
+			assert.Equal(t, tc.expectEncoding, responseCompressionEncoding(req))
 		})
 	}
 }
@@ -165,6 +223,25 @@ func TestHandler_AcceptEncoding_MultipleEncodings(t *testing.T) {
 
 	res := w.Result()
 	assert.Equal(t, "gzip", res.Header.Get("grpc-encoding"))
+}
+
+func TestHandler_AcceptEncoding_DeflateOnly(t *testing.T) {
+	handler := newTestHandler(t)
+
+	req := httptest.NewRequest("POST", "/connectrpc.eliza.v1.ElizaService/Say", makeUnaryBody(t))
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("grpc-accept-encoding", "deflate")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	assert.Equal(t, "deflate", res.Header.Get("grpc-encoding"))
+
+	respBytes, ok := readDeflateFrame(t, res.Body)
+	require.True(t, ok)
+	var msg elizav1.SayResponse
+	require.NoError(t, proto.Unmarshal(respBytes, &msg))
 }
 
 // TestHandler_AcceptEncoding_IdentityOnly verifies that a client advertising

--- a/private/server/handler.go
+++ b/private/server/handler.go
@@ -129,12 +129,12 @@ func NewHandler(service protoreflect.ServiceDescriptor, faker fauxrpc.ProtoFaker
 		w.Header().Set("Trailer", "Grpc-Status,Grpc-Message,Grpc-Status-Details-Bin")
 		w.Header().Add("Content-Type", "application/grpc")
 
-		// Compress responses when the client advertises gzip acceptance via
-		// grpc-accept-encoding, or implicitly via grpc-encoding on the request.
 		writeMessage := grpc.WriteGRPCMessage
-		if clientAcceptsGzip(r) {
-			w.Header().Set("grpc-encoding", "gzip")
-			writeMessage = grpc.WriteGRPCMessageGzip
+		if enc := responseCompressionEncoding(r); enc != "" {
+			w.Header().Set("grpc-encoding", enc)
+			writeMessage = func(w io.Writer, msg []byte) error {
+				return grpc.WriteGRPCMessageCompressed(w, msg, enc)
+			}
 		}
 		if len(parts) != 3 {
 			s.IncrementErrors()
@@ -194,9 +194,10 @@ func NewHandler(service protoreflect.ServiceDescriptor, faker fauxrpc.ProtoFaker
 
 		readMessageBuf := bufferPool.Get().(*[]byte)
 		defer bufferPool.Put(readMessageBuf)
+		requestEncoding := strings.ToLower(strings.TrimSpace(r.Header.Get("grpc-encoding")))
 
 		readMessage := func() (releasableMessage, *status.Status) {
-			size, err := grpc.ReadGRPCMessage(r.Body, *readMessageBuf)
+			size, err := grpc.ReadGRPCMessageWithEncoding(r.Body, *readMessageBuf, requestEncoding)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return nil, nil

--- a/private/server/handler_gzip_test.go
+++ b/private/server/handler_gzip_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/binary"
 	"io"
 	"net/http"
@@ -42,6 +44,51 @@ func writeMsgGzip(t *testing.T, w io.Writer, msg proto.Message) {
 	require.NoError(t, err)
 }
 
+// writeMsgDeflate writes a zlib-wrapped deflate gRPC frame (flag=1).
+func writeMsgDeflate(t *testing.T, w io.Writer, msg proto.Message) {
+	t.Helper()
+	b, err := proto.Marshal(msg)
+	require.NoError(t, err)
+
+	var compressed bytes.Buffer
+	zw := zlib.NewWriter(&compressed)
+	_, err = zw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	payload := compressed.Bytes()
+	prefix := make([]byte, 5)
+	prefix[0] = 1 // compressed
+	binary.BigEndian.PutUint32(prefix[1:], uint32(len(payload)))
+	_, err = w.Write(prefix)
+	require.NoError(t, err)
+	_, err = w.Write(payload)
+	require.NoError(t, err)
+}
+
+// writeMsgRawDeflate writes a raw RFC 1951 deflate gRPC frame (flag=1).
+func writeMsgRawDeflate(t *testing.T, w io.Writer, msg proto.Message) {
+	t.Helper()
+	b, err := proto.Marshal(msg)
+	require.NoError(t, err)
+
+	var compressed bytes.Buffer
+	fw, err := flate.NewWriter(&compressed, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = fw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, fw.Close())
+
+	payload := compressed.Bytes()
+	prefix := make([]byte, 5)
+	prefix[0] = 1 // compressed
+	binary.BigEndian.PutUint32(prefix[1:], uint32(len(payload)))
+	_, err = w.Write(prefix)
+	require.NoError(t, err)
+	_, err = w.Write(payload)
+	require.NoError(t, err)
+}
+
 // readGzipFrame reads one gRPC length-prefixed frame and decompresses it if flag=1.
 func readGzipFrame(t *testing.T, r io.Reader) ([]byte, bool) {
 	t.Helper()
@@ -70,6 +117,38 @@ func readGzipFrame(t *testing.T, r io.Reader) ([]byte, bool) {
 	require.NoError(t, err)
 	decompressed, err := io.ReadAll(gr)
 	require.NoError(t, err)
+	return decompressed, true
+}
+
+// readDeflateFrame reads one zlib-wrapped deflate gRPC frame.
+func readDeflateFrame(t *testing.T, r io.Reader) ([]byte, bool) {
+	t.Helper()
+	prefix := make([]byte, 5)
+	_, err := io.ReadFull(r, prefix)
+	if err == io.EOF {
+		return nil, false
+	}
+	require.NoError(t, err)
+
+	isCompressed := prefix[0] == 1
+	size := binary.BigEndian.Uint32(prefix[1:])
+	if size == 0 {
+		return nil, true
+	}
+
+	payload := make([]byte, size)
+	_, err = io.ReadFull(r, payload)
+	require.NoError(t, err)
+
+	if !isCompressed {
+		return payload, true
+	}
+
+	zr, err := zlib.NewReader(bytes.NewReader(payload))
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
 	return decompressed, true
 }
 
@@ -131,6 +210,30 @@ func TestHandler_GzipRequest_UnaryResponse(t *testing.T) {
 		grpcStatus = res.Header.Get("Grpc-Status")
 	}
 	assert.Equal(t, "0", grpcStatus)
+}
+
+func TestHandler_DeflateRequest_UnaryResponse(t *testing.T) {
+	handler := newElizaHandler(t)
+
+	var body bytes.Buffer
+	writeMsgDeflate(t, &body, &elizav1.SayRequest{Sentence: "hello from deflate"})
+
+	req := httptest.NewRequest("POST", "/connectrpc.eliza.v1.ElizaService/Say", &body)
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("grpc-encoding", "deflate")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "deflate", res.Header.Get("grpc-encoding"))
+
+	respBytes, ok := readDeflateFrame(t, res.Body)
+	require.True(t, ok)
+
+	var respMsg elizav1.SayResponse
+	require.NoError(t, proto.Unmarshal(respBytes, &respMsg))
 }
 
 // TestHandler_UncompressedRequest_UncompressedResponse verifies the baseline
@@ -246,4 +349,24 @@ func TestHandler_GzipRequest_InvalidPayload(t *testing.T) {
 	assert.NotEmpty(t, grpcStatus)
 	// Specifically, this should be NotFound (4) or Internal (13), not OK (0).
 	assert.NotEqual(t, codes.OK.String(), grpcStatus)
+}
+
+func TestHandler_DeflateRequest_RejectsRawDeflatePayload(t *testing.T) {
+	handler := newElizaHandler(t)
+
+	var body bytes.Buffer
+	writeMsgRawDeflate(t, &body, &elizav1.SayRequest{Sentence: "raw deflate"})
+
+	req := httptest.NewRequest("POST", "/connectrpc.eliza.v1.ElizaService/Say",
+		bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("grpc-encoding", "deflate")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	grpcStatus := res.Header.Get("Grpc-Status")
+	assert.NotEqual(t, "0", grpcStatus, "expected non-OK grpc status for raw deflate payload")
+	assert.NotEmpty(t, grpcStatus)
 }

--- a/private/server/proxy.go
+++ b/private/server/proxy.go
@@ -145,16 +145,17 @@ func handleProxy(
 		}
 	}
 
-	// Compress responses when the client advertises gzip acceptance via
-	// grpc-accept-encoding, or implicitly via grpc-encoding on the request.
-	compressResp := clientAcceptsGzip(r)
+	responseEncoding := responseCompressionEncoding(r)
 	writeMessage := grpc.WriteGRPCMessage
-	if compressResp {
-		writeMessage = grpc.WriteGRPCMessageGzip
+	if responseEncoding != "" {
+		writeMessage = func(w io.Writer, msg []byte) error {
+			return grpc.WriteGRPCMessageCompressed(w, msg, responseEncoding)
+		}
 	}
+	requestEncoding := strings.ToLower(strings.TrimSpace(r.Header.Get("grpc-encoding")))
 
 	if !isClientStream && !isServerStream {
-		reqMsg, st := readUnaryRequest(r, method.Input())
+		reqMsg, st := readUnaryRequest(r, method.Input(), requestEncoding)
 		if st != nil {
 			return st.Err()
 		}
@@ -178,8 +179,8 @@ func handleProxy(
 
 		copyHeaders(resp.Header(), w.Header())
 		w.Header().Set("x-fauxrpc-source", "proxy")
-		if compressResp {
-			w.Header().Set("grpc-encoding", "gzip")
+		if responseEncoding != "" {
+			w.Header().Set("grpc-encoding", responseEncoding)
 		}
 		*responseBody = resp.Msg
 
@@ -191,7 +192,7 @@ func handleProxy(
 	}
 
 	if !isClientStream && isServerStream {
-		reqMsg, st := readUnaryRequest(r, method.Input())
+		reqMsg, st := readUnaryRequest(r, method.Input(), requestEncoding)
 		if st != nil {
 			return st.Err()
 		}
@@ -215,8 +216,8 @@ func handleProxy(
 
 		copyHeaders(stream.ResponseHeader(), w.Header())
 		w.Header().Set("x-fauxrpc-source", "proxy")
-		if compressResp {
-			w.Header().Set("grpc-encoding", "gzip")
+		if responseEncoding != "" {
+			w.Header().Set("grpc-encoding", responseEncoding)
 		}
 
 		for stream.Receive() {
@@ -249,7 +250,7 @@ func handleProxy(
 		defer bufferPool.Put(readMessageBuf)
 
 		for {
-			size, err := grpc.ReadGRPCMessage(r.Body, *readMessageBuf)
+			size, err := grpc.ReadGRPCMessageWithEncoding(r.Body, *readMessageBuf, requestEncoding)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					break
@@ -298,8 +299,8 @@ func handleProxy(
 
 		copyHeaders(resp.Header(), w.Header())
 		w.Header().Set("x-fauxrpc-source", "proxy")
-		if compressResp {
-			w.Header().Set("grpc-encoding", "gzip")
+		if responseEncoding != "" {
+			w.Header().Set("grpc-encoding", responseEncoding)
 		}
 		*responseBody = resp.Msg
 
@@ -322,7 +323,7 @@ func handleProxy(
 			defer bufferPool.Put(readMessageBuf)
 
 			for {
-				size, err := grpc.ReadGRPCMessage(r.Body, *readMessageBuf)
+				size, err := grpc.ReadGRPCMessageWithEncoding(r.Body, *readMessageBuf, requestEncoding)
 				if err != nil {
 					if errors.Is(err, io.EOF) {
 						break
@@ -387,8 +388,8 @@ func handleProxy(
 
 		copyHeaders(bidiStream.ResponseHeader(), w.Header())
 		w.Header().Set("x-fauxrpc-source", "proxy")
-		if compressResp {
-			w.Header().Set("grpc-encoding", "gzip")
+		if responseEncoding != "" {
+			w.Header().Set("grpc-encoding", responseEncoding)
 		}
 
 		return err
@@ -397,11 +398,11 @@ func handleProxy(
 	return nil
 }
 
-func readUnaryRequest(r *http.Request, md protoreflect.MessageDescriptor) (releasableMessage, *status.Status) {
+func readUnaryRequest(r *http.Request, md protoreflect.MessageDescriptor, encoding string) (releasableMessage, *status.Status) {
 	readMessageBuf := bufferPool.Get().(*[]byte)
 	defer bufferPool.Put(readMessageBuf)
 
-	size, err := grpc.ReadGRPCMessage(r.Body, *readMessageBuf)
+	size, err := grpc.ReadGRPCMessageWithEncoding(r.Body, *readMessageBuf, encoding)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, nil


### PR DESCRIPTION
Add support for deflate

> Like HTTP implementations, gRPC implementations MUST use the "deflate" compression to mean the zlib structure (defined in [RFC 1950](https://datatracker.ietf.org/doc/html/rfc1950)) with the deflate compression algorithm (defined in [RFC 1951](https://datatracker.ietf.org/doc/html/rfc1951)). Servers and clients MUST NOT send raw deflate data.

src: https://github.com/grpc/grpc/blob/master/doc/compression.md